### PR TITLE
#240 CFG header selectors: fix: refactor css selectors

### DIFF
--- a/src/app/components/courses-for-groups/added-courses/added-courses.component.html
+++ b/src/app/components/courses-for-groups/added-courses/added-courses.component.html
@@ -3,39 +3,39 @@
     <table class="table table-striped table-sm fs-13">
       <thead>
         <tr>
-          <th>
+          <th class="text-center">
             <input type="checkbox" #selectedAll (change)="changeAllIsSelected(selectedAll.checked)"
                    [ngModel]="allRowsIsSelected">
           </th>
           <th>Назва</th>
           <th>Вид</th>
-          <th>Години</th>
-          <th>Кредити</th>
+          <th class="text-right">Години</th>
+          <th class="text-right">Кредити</th>
           <th>Викладач</th>
           <th>А.Р</th>
           <th>Дата іспиту</th>
         <tr>
       </thead>
       <tr *ngFor="let course of coursesForGroup" [class.academic-difference]="course.academicDifference">
-        <td><input type="checkbox" #selected (change)="changeCoursesForDelete($event.target.checked, course)"
+        <td class="text-center"><input type="checkbox" #selected (change)="changeCoursesForDelete($event.target.checked, course)"
                    [checked]="allRowsIsSelected"></td>
         <td>{{ course.course.courseName.name }}</td>
         <td>{{ course.course.knowledgeControl.name}}</td>
-        <td>{{ course.course.hours }}</td>
-        <td>{{ course.course.credits }}</td>
+        <td class="text-right">{{ course.course.hours }}</td>
+        <td class="text-right">{{ course.course.credits }}</td>
         <td (click)="changeTeacher(course)">
           <button class="btn btn-outline-secondary">
             {{ (course.teacher | nameWithInitials) || 'Вибрати' }}
           </button>
         </td>
-        <td><input type="checkbox" [checked]="course.academicDifference"
+        <td class="text-center"><input type="checkbox" [checked]="course.academicDifference"
                    [(ngModel)]="course.academicDifference"
                    (change)="onAcademicDifferenceChange(course)"
         ></td>
         <td><input class="form-control mr-2 ng-pristine ng-valid ng-touched" type="date" [(ngModel)]="course.examDate"
                    (change)="dateChange(course)">
         </td>
-        <td (click)="changeCourse(course)">
+        <td class="text-center" (click)="changeCourse(course)">
           <button type="button" class="btn btn-outline-info" [disabled]="changesExistence">
             Редагувати курс
           </button>

--- a/src/app/components/courses-for-groups/courses-for-groups.component.html
+++ b/src/app/components/courses-for-groups/courses-for-groups.component.html
@@ -58,13 +58,13 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <button type="button" class="btn btn-info ml-0" (click)="addCoursesToCoursesForGroup()"
+      <button type="button" class="btn btn-info btn-medium ml-1" (click)="addCoursesToCoursesForGroup()"
               [disabled]="!selectedCourses.length">Призначити
       </button>
-      <button type="button" class="btn btn-danger" (click)="checkAddedCoursesForDeleting()"
+      <button type="button" class="btn btn-danger btn-medium" (click)="checkAddedCoursesForDeleting()"
               [disabled]="!coursesForDelete.length">Видалити
       </button>
-      <button type="button" class="btn btn-info copy" (click)="copyCourses()"
+      <button type="button" class="btn btn-info" (click)="copyCourses()"
               *ngIf="selectedGroup&&selectedSemester">Скопіювати з іншої групи
       </button>
       <button type="button" class="btn btn-warning" (click)="showGroupsDifferents()"
@@ -88,14 +88,14 @@
                    [selectedGroup]="selectedGroup"
                    [changesExistence]="changesExistence"></added-courses>
   </div>
-  <div class="bg-white fixed-bottom">
+  <div class="bg-white fixed-bottom ml-3">
     <simple-notifications></simple-notifications>
     <div class="row">
       <div class="col-11">
-        <button type="button" class="btn btn-success ml-3" (click)="saveCoursesForGroup()"
+        <button type="button" class="btn btn-success btn-medium ml-1 " (click)="saveCoursesForGroup()"
                 [disabled]="!changesExistence">Зберегти
         </button>
-        <button type="button" class="btn btn-danger" (click)="onGroupChange()"
+        <button type="button" class="btn btn-danger btn-medium" (click)="onGroupChange()"
                 [disabled]="!changesExistence">Відмінити зміни
         </button>
       </div>

--- a/src/app/components/courses-for-groups/courses-for-groups.component.html
+++ b/src/app/components/courses-for-groups/courses-for-groups.component.html
@@ -8,7 +8,7 @@
         <div class="element">
           <div class="element-header">Група:</div>
           <div class="col-2">
-            <select id="group" class="form-control mr-2 ng-pristine ng-valid ng-touched" [(ngModel)]="selectedGroup"
+            <select id="group" class="form-control mr-2" [(ngModel)]="selectedGroup"
                   (change)="onGroupChange()">
               <option *ngFor="let group of groups" [ngValue]="group">{{group.name}}</option>
             </select>
@@ -17,7 +17,7 @@
         <div class="element">
           <div class="element-header">Семестр:</div>
           <div class="col-1">
-            <select id="semester" class="form-control mr-2 ng-pristine ng-valid ng-touched" [(ngModel)]="selectedSemester"
+            <select id="semester" class="form-control mr-2" [(ngModel)]="selectedSemester"
                   (change)="onSemesterChange()">
               <option *ngFor="let semester of semesters" [ngValue]="semester">{{semester}}</option>
             </select>
@@ -26,7 +26,7 @@
         <div class="element">
           <div class="element-header">Годин за кредит:</div>
           <div class="col-1">
-            <select class="form-control mr-2 ng-pristine ng-valid ng-touched"
+            <select class="form-control mr-2"
                 [(ngModel)]="selectedHoursPerCredit" (change)="onChangeHoursPerCredit()" [disabled]="hoursPerCreditCBDisabled">
             <option [ngValue]="30">30</option>
             <option [ngValue]="36">36</option>
@@ -35,7 +35,7 @@
         </div>
         <div class="col-4">
           <input [(ngModel)]="searchText" placeholder="Пошук за предметом"
-                 class="form-control mr-2 ng-pristine ng-valid ng-touched search">
+                 class="form-control mr-2 search">
         </div>
       </div>
     </div>
@@ -58,7 +58,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <button type="button" class="btn btn-info" (click)="addCoursesToCoursesForGroup()"
+      <button type="button" class="btn btn-info ml-0" (click)="addCoursesToCoursesForGroup()"
               [disabled]="!selectedCourses.length">Призначити
       </button>
       <button type="button" class="btn btn-danger" (click)="checkAddedCoursesForDeleting()"
@@ -88,11 +88,11 @@
                    [selectedGroup]="selectedGroup"
                    [changesExistence]="changesExistence"></added-courses>
   </div>
-  <div class="bg-white fixed-bottom p-1">
+  <div class="bg-white fixed-bottom">
     <simple-notifications></simple-notifications>
-    <div class="row bottom-row">
+    <div class="row">
       <div class="col-11">
-        <button type="button" class="btn btn-success" (click)="saveCoursesForGroup()"
+        <button type="button" class="btn btn-success ml-3" (click)="saveCoursesForGroup()"
                 [disabled]="!changesExistence">Зберегти
         </button>
         <button type="button" class="btn btn-danger" (click)="onGroupChange()"

--- a/src/app/components/courses-for-groups/courses-for-groups.component.scss
+++ b/src/app/components/courses-for-groups/courses-for-groups.component.scss
@@ -1,32 +1,21 @@
-.selection{
+div {
+  font-size: 15px;
+}
+
+.courses-for-groups {
+  height: calc(100% - 108px);
+}
+
+.selection {
   margin-top: 10px;
   margin-bottom: 10px;
   overflow: hidden;
-}
 
-.btn-info{
-  margin: 10px;
-}
-
-.search {
-  float: right;
-  clear: both;
-}
-
-.mr-2[_ngcontent-c2], .mx-2[_ngcontent-c2]{
-  margin-right: 0 !important;
-}
-
-.btn-info[_ngcontent-c2] {
-  margin-left: 0;
-}
-
-.btn-success[_ngcontent-c2] {
-  margin-left: 0;
-}
-
-.copy[_ngcontent-c2] {
-  margin-left: 10px;
+  .form-control {
+    height: 1.5rem;
+    font-size: 15px;
+    padding: 0 0.75rem;
+  }
 }
 
 .btn {
@@ -35,56 +24,7 @@
   padding: 0.2rem 0.75rem;
 }
 
-.count-label{
-  margin-top: 15px;
-  font-size: 15px;
-}
-
-div {
-  font-size: 15px;
-}
-
-.div-table {
-  height: 100%;
-}
-
-.form-control .mr-2 .ng-pristine .ng-valid .ng-touched{
-  height: 1.5rem;
-  font-size: 15px;
-}
-
-.form-control {
-  height: 1.5rem;
-  font-size: 15px;
-}
-
-select.form-control[_ngcontent-c2]:not([size]):not([multiple]) {
-  height: 1.5rem;
-  padding: 0 0.75rem;
-}
-
-.bottom-row{
-  margin-left: 0;
-}
-
-.course-for-group-table{
-  height: 50%;
-  overflow: auto;
-}
-
-.courses{
-  height: 40%;
-}
-
-.studied-courses{
-  height: 100%;
-  overflow: auto;
-}
-
-.courses-for-groups{
-  height: calc(100% - 108px);
-}
-.menu-row{
+.menu-row {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -94,14 +34,31 @@ select.form-control[_ngcontent-c2]:not([size]):not([multiple]) {
   display: inline-flex;
   flex-direction: row;
   justify-content: flex-start;
+
+  .element-header {
+    margin-right: 5px;
+    min-width: auto;
+  }
 }
-.element-header{
-  margin-right: 5px;
-  min-width: auto;
+
+.courses{
+  height: 40%;
+
+  .studied-courses{
+    height: 100%;
+    overflow: auto;
+  }
+
 }
+
+.course-for-group-table{
+  height: 50%;
+  overflow: auto;
+}
+
 .col-1 {
-  min-width: 4.8em;
   padding: 1px;
+  min-width: 4.8em;
 }
 
 .col-2 {
@@ -113,3 +70,6 @@ select.form-control[_ngcontent-c2]:not([size]):not([multiple]) {
   padding: 1px;
 }
 
+.count-label {
+  margin-top: 15px;
+}

--- a/src/app/components/courses-for-groups/courses-for-groups.component.scss
+++ b/src/app/components/courses-for-groups/courses-for-groups.component.scss
@@ -22,6 +22,11 @@ div {
   height: 2rem;
   margin: 7px;
   padding: 0.2rem 0.75rem;
+
+  &.btn-medium {
+    width: 145px;
+  }
+
 }
 
 .menu-row {

--- a/src/app/components/courses-for-groups/studied-courses/studied-courses.component.html
+++ b/src/app/components/courses-for-groups/studied-courses/studied-courses.component.html
@@ -7,17 +7,17 @@
           <th *ngIf="courses"></th>
           <th>Назва</th>
           <th>Контроль</th>
-          <th>Години</th>
-          <th>Кредити</th>
+          <th class="text-right">Години</th>
+          <th class="text-right">Кредити</th>
         </tr>
       </thead>
       <tr *ngFor="let course of courses | coursesSearch : searchText">
-        <td><input type="checkbox" [(ngModel)]="course.selected"
+        <td class="text-center"><input type="checkbox" [(ngModel)]="course.selected"
                    (change)="changeSelectedCoursesList($event.target.checked, course)"></td>
         <td>{{ course.courseName.name }}</td>
         <td>{{ course.knowledgeControl.name }}</td>
-        <td>{{ course.hours }}</td>
-        <td>{{ course.credits }}</td>
+        <td class="text-right">{{ course.hours }}</td>
+        <td class="text-right">{{ course.credits }}</td>
       </tr>
     </table>
     <loading *ngIf="loading"></loading>


### PR DESCRIPTION
Задав кнопкам "Призначити", "Видалити", "Зберегти", "Відмінити зміни" однаковий розмір
![image](https://user-images.githubusercontent.com/11459840/60899657-7aff4800-a273-11e9-95a1-c4a53392e0d1.png)
Для сітки використав розширення для хрому https://chrome.google.com/webstore/detail/grid-ruler/joadogiaiabhmggdifljlpkclnpfncmj

Числові данні в таблицях вирівняв по правому краю
https://medium.com/mission-log/design-better-data-tables-430a30a00d8c
1. Numerical data is right-aligned
2. Textual data is left-aligned
3. Headers are aligned with their data
3½. Don’t use center alignment.

Для того, щоб переконатися що зміни нічого зайвого не затронили використав розширення
https://chrome.google.com/webstore/detail/look-alike/ilgnnafljmfofogfllhejmihafdbalgc

![image](https://user-images.githubusercontent.com/11459840/60899912-f82abd00-a273-11e9-9447-0342a5d3d2ce.png)


![image](https://user-images.githubusercontent.com/11459840/60900175-70917e00-a274-11e9-84e5-7f621b544366.png)




