### PR TITLE
376 Адміністратор може знайти всі назви предметів, що не використовуються ніде, та видалити їх

### DIFF
--- a/src/app/components/administration-tool/administration-tool.module.ts
+++ b/src/app/components/administration-tool/administration-tool.module.ts
@@ -7,6 +7,7 @@ import {MatRadioModule} from '@angular/material/radio';
 import {SharedModule} from '../shared/shared.module';
 import {PipeModule} from '../../pipes/pipe.module';
 import { SimilarSubjectsComponent } from './similar-subjects/similar-subjects.component';
+import { CourseNameCleaningComponent } from './course-name-cleaning/course-name-cleaning.component';
 
 export const abstractRoutes: Routes = [
   {
@@ -17,6 +18,10 @@ export const abstractRoutes: Routes = [
   {
     path: 'similar-subjects',
     component: SimilarSubjectsComponent,
+  },
+  {
+    path: 'course-name-cleaning',
+    component: CourseNameCleaningComponent,
   }
 ];
 
@@ -29,6 +34,6 @@ export const abstractRoutes: Routes = [
     MatRadioModule,
     RouterModule.forChild(abstractRoutes)
   ],
-  declarations: [SimilarSubjectsComponent]
+  declarations: [SimilarSubjectsComponent, CourseNameCleaningComponent]
 })
 export class AdministrationToolModule { }

--- a/src/app/components/administration-tool/course-name-cleaning/column-definitions.ts
+++ b/src/app/components/administration-tool/course-name-cleaning/column-definitions.ts
@@ -1,0 +1,36 @@
+import {Course} from '../../../models/Course';
+
+export const COLUMN_DEFINITIONS: [{
+  headerName: string;
+  field?: string;
+  checkboxSelection?: boolean;
+  minWidth?: number;
+  maxWidth?: number;
+  width?: number;
+  valueGetter?: (params: {data: Course, node, column, colDef, api, columnApi, getValue: () => any}) => string | void;
+}] = [
+  {
+    headerName: '#',
+    checkboxSelection: true,
+    maxWidth: 40,
+  },
+  {
+    headerName: 'ID',
+    field: 'id',
+    maxWidth: 80,
+  },
+  {
+    headerName: 'Назва',
+    field: 'name',
+  },
+  {
+    headerName: 'Назва англ.',
+    field: 'nameEng',
+    maxWidth: 120,
+  },
+  {
+    headerName: 'Аббревіатура',
+    field: 'abbr',
+    maxWidth: 160,
+  },
+];

--- a/src/app/components/administration-tool/course-name-cleaning/column-definitions.ts
+++ b/src/app/components/administration-tool/course-name-cleaning/column-definitions.ts
@@ -26,11 +26,11 @@ export const COLUMN_DEFINITIONS: [{
   {
     headerName: 'Назва англ.',
     field: 'nameEng',
-    maxWidth: 120,
+    maxWidth: 250,
   },
   {
     headerName: 'Аббревіатура',
-    field: 'abbr',
-    maxWidth: 160,
+    field: 'abbreviation',
+    maxWidth: 200,
   },
 ];

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.html
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.html
@@ -1,0 +1,40 @@
+<div class="header">
+  <div>
+    <h4>
+      Назви предметів, які не використовуються
+    </h4>
+    <section title="Кількість груп предметів, які схожі між собою">
+      Всього предметів: {{ (courseNames$ | async)?.length }}
+    </section>
+  </div>
+  <div>
+    <button class="btn btn-primary" (click)="deleteUnusedCourseNames()" [attr.disabled]="selectedCourseNames?.length <= 0 ? true : null">
+      <ng-container *ngIf="!dataProcessing; else data_processing">
+        Виправити
+        ({{ selectedCourseNames?.length }})
+      </ng-container>
+      <ng-template #data_processing>
+        Обробка даних...
+      </ng-template>
+    </button>
+  </div>
+</div>
+<div class="accordion" id="similarCourseAccordion">
+  <ag-grid-angular
+    class="ag-theme-balham overflow-auto h-100"
+    rowHeight="50"
+    rowSelection="multiple"
+    enableCellChangeFlash=true
+    [animateRows]="true"
+    [accentedSort]="true"
+    [rowData]="courseNames$ | async"
+    [columnDefs]="columnDefs"
+    [defaultColDef]="defaultColDef"
+    [localeText]="localeText"
+    [getRowNodeId]="getRowNodeId"
+    (selectionChanged)="onSelectionChanged($event)"
+    (gridReady)="onGridReady($event)"
+    (modelUpdated)="onModelUpdated($event)"
+  >
+  </ag-grid-angular>
+</div>

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.html
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.html
@@ -4,13 +4,13 @@
       Назви предметів, які не використовуються
     </h4>
     <section title="Кількість груп предметів, які схожі між собою">
-      Всього предметів: {{ (courseNames$ | async)?.length }}
+      Всього назв предметів: {{ (courseNames$ | async)?.length }}
     </section>
   </div>
   <div>
     <button class="btn btn-primary" (click)="deleteUnusedCourseNames()" [attr.disabled]="selectedCourseNames?.length <= 0 ? true : null">
       <ng-container *ngIf="!dataProcessing; else data_processing">
-        Виправити
+        Видалити
         ({{ selectedCourseNames?.length }})
       </ng-container>
       <ng-template #data_processing>
@@ -20,21 +20,28 @@
   </div>
 </div>
 <div class="accordion" id="similarCourseAccordion">
-  <ag-grid-angular
-    class="ag-theme-balham overflow-auto h-100"
-    rowHeight="50"
-    rowSelection="multiple"
-    enableCellChangeFlash=true
-    [animateRows]="true"
-    [accentedSort]="true"
-    [rowData]="courseNames$ | async"
-    [columnDefs]="columnDefs"
-    [defaultColDef]="defaultColDef"
-    [localeText]="localeText"
-    [getRowNodeId]="getRowNodeId"
-    (selectionChanged)="onSelectionChanged($event)"
-    (gridReady)="onGridReady($event)"
-    (modelUpdated)="onModelUpdated($event)"
-  >
-  </ag-grid-angular>
+  <ng-container *ngIf="(courseNames$ | async)?.length > 0; else no_data">
+    <ag-grid-angular
+      class="ag-theme-balham overflow-auto h-100"
+      rowHeight="50"
+      rowSelection="multiple"
+      enableCellChangeFlash=true
+      [animateRows]="true"
+      [accentedSort]="true"
+      [rowData]="courseNames$ | async"
+      [columnDefs]="columnDefs"
+      [defaultColDef]="defaultColDef"
+      [localeText]="localeText"
+      [getRowNodeId]="getRowNodeId"
+      (selectionChanged)="onSelectionChanged($event)"
+      (gridReady)="onGridReady($event)"
+      (modelUpdated)="onModelUpdated($event)"
+    >
+    </ag-grid-angular>
+  </ng-container>
+  <ng-template #no_data>
+    <div class="header">
+      Немає назв предметів, які не використовуються
+    </div>
+  </ng-template>
 </div>

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.scss
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.scss
@@ -1,0 +1,5 @@
+.header {
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.spec.ts
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CourseNameCleaningComponent } from './course-name-cleaning.component';
+
+describe('CourseNameCleaningComponent', () => {
+  let component: CourseNameCleaningComponent;
+  let fixture: ComponentFixture<CourseNameCleaningComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CourseNameCleaningComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CourseNameCleaningComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.ts
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.ts
@@ -1,0 +1,69 @@
+import { Component, OnInit } from '@angular/core';
+import {DEFAULT_COLUMN_DEFINITIONS, LOCALE_TEXT} from '../../shared/constant';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {AdministrationToolService} from '../../../services/administration-tool.service';
+import {CourseName} from '../../../models/CourseName';
+import {finalize} from 'rxjs/operators';
+import {SelectionChangedEvent, ModelUpdatedEvent, GridReadyEvent} from 'ag-grid-community';
+import {COLUMN_DEFINITIONS} from './column-definitions';
+
+@Component({
+  selector: 'course-name-cleaning',
+  templateUrl: './course-name-cleaning.component.html',
+  styleUrls: ['./course-name-cleaning.component.scss']
+})
+export class CourseNameCleaningComponent implements OnInit {
+
+  defaultColDef = {
+    ...DEFAULT_COLUMN_DEFINITIONS
+  };
+  columnDefs = COLUMN_DEFINITIONS;
+  localeText = LOCALE_TEXT;
+  public courseNames$: BehaviorSubject<CourseName[]> = new BehaviorSubject<CourseName[]>([]);
+  private grid = {
+    api: null,
+    columnApi: null,
+  };
+  private count: number;
+  public selectedCourseNames: CourseName[] = [];
+  public dataProcessing = false;
+
+  getRowNodeId = (data) => data.id;
+
+  constructor(private adminTool: AdministrationToolService) { }
+
+  ngOnInit() {
+    this.getUnusedCourseNames();
+  }
+
+  getUnusedCourseNames() {
+    this.adminTool.getUnusedCourseNames()
+      .subscribe(courseNames => this.courseNames$.next(courseNames));
+  }
+
+  onGridReady(params: GridReadyEvent) {
+    this.grid.api = params.api;
+    this.grid.columnApi = params.columnApi;
+    this.grid.api.sizeColumnsToFit();
+  }
+
+  onModelUpdated(params: ModelUpdatedEvent) {
+    this.count = params.api.getDisplayedRowCount();
+  }
+
+  onSelectionChanged(event: SelectionChangedEvent) {
+    this.selectedCourseNames = event.api.getSelectedRows();
+  }
+
+
+  deleteUnusedCourseNames() {
+    this.dataProcessing = true;
+    this.adminTool.deleteUnusedCourseNames(this.selectedCourseNames.map(value => value.id))
+      .pipe(
+        finalize(() => this.dataProcessing = false),
+      )
+      .subscribe(() => {
+        this.getUnusedCourseNames();
+      });
+  }
+}

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.ts
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.ts
@@ -4,7 +4,7 @@ import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {AdministrationToolService} from '../../../services/administration-tool.service';
 import {CourseName} from '../../../models/CourseName';
 import {finalize} from 'rxjs/operators';
-import {SelectionChangedEvent, ModelUpdatedEvent, GridReadyEvent} from 'ag-grid-community';
+import {SelectionChangedEvent, ModelUpdatedEvent, GridReadyEvent} from '@ag-grid-community/all-modules';
 import {COLUMN_DEFINITIONS} from './column-definitions';
 
 @Component({

--- a/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.ts
+++ b/src/app/components/administration-tool/course-name-cleaning/course-name-cleaning.component.ts
@@ -64,6 +64,7 @@ export class CourseNameCleaningComponent implements OnInit {
       )
       .subscribe(() => {
         this.getUnusedCourseNames();
+        this.selectedCourseNames = [];
       });
   }
 }

--- a/src/app/components/app/header/header.component.html
+++ b/src/app/components/app/header/header.component.html
@@ -76,6 +76,12 @@
              routerLinkActive="active">
             Схожі предмети
           </a>
+          <a [routerLinkActiveOptions]="{exact: true}"
+             class="dropdown-item"
+             routerLink="/dashboard/administration-tool/course-name-cleaning"
+             routerLinkActive="active">
+            Очистка назв предметів
+          </a>
         </div>
       </li>
     </ul>

--- a/src/app/components/courses-for-groups/courses-for-groups.component.ts
+++ b/src/app/components/courses-for-groups/courses-for-groups.component.ts
@@ -194,7 +194,7 @@ export class CoursesForGroupsComponent implements OnInit {
     }
     this.sortCoursesForGroup();
     this.studiedCoursesChild.courses.forEach(course => course.selected = false);
-    this.studiedCoursesChild.selectedCourses = [];
+    this.studiedCoursesChild.selectedCourseNames = [];
     this.selectedCourses = [];
   }
 
@@ -291,7 +291,7 @@ export class CoursesForGroupsComponent implements OnInit {
     this.coursesForGroup = [];
     this.addedCoursesChild.coursesForGroup = [];
     this.selectedCourses = [];
-    this.studiedCoursesChild.selectedCourses = [];
+    this.studiedCoursesChild.selectedCourseNames = [];
     this.changesExistence = false;
   }
 

--- a/src/app/services/administration-tool.service.ts
+++ b/src/app/services/administration-tool.service.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {environment} from '../../environments/environment';
 import {Observable} from 'rxjs/Observable';
+import {CourseName} from '../models/CourseName';
 
 export interface SimilarCourse {
   id: number;
@@ -22,6 +23,14 @@ export class AdministrationToolService {
 
   public mergeSimilarCourses(mergeStructure: {[key: string]: number[]}): Observable<Object> {
     return this.httpClient.post(AdministrationToolService.BASE_URL + '/merge', mergeStructure);
+  }
+
+  public getUnusedCourseNames(): Observable<CourseName[]> {
+    return this.httpClient.get<CourseName[]>(AdministrationToolService.BASE_URL + '/course-names/unused');
+  }
+
+  public deleteUnusedCourseNames(courseNameIds: number[]): Observable<void> {
+    return this.httpClient.delete<void>(AdministrationToolService.BASE_URL + '/course-names/unused');
   }
 
 }

--- a/src/app/services/administration-tool.service.ts
+++ b/src/app/services/administration-tool.service.ts
@@ -30,7 +30,11 @@ export class AdministrationToolService {
   }
 
   public deleteUnusedCourseNames(courseNameIds: number[]): Observable<void> {
-    return this.httpClient.delete<void>(AdministrationToolService.BASE_URL + '/course-names/unused');
+    return this.httpClient.delete<void>(AdministrationToolService.BASE_URL + '/course-names', {
+      params: {
+        ids: courseNameIds,
+      }
+    });
   }
 
 }


### PR DESCRIPTION
Задача була реалізована. Був доданий новий пункт меню та сторінка для відображення всіх назв предметів, які не використовуються, та можливість їх видалення. Зараз сторінка виглядає як на скриншоті нижче:
![image](https://user-images.githubusercontent.com/35197419/74610329-faeb6b80-50fa-11ea-8dbe-f55db19a2beb.png)
